### PR TITLE
Implement per-note categories aggregation

### DIFF
--- a/interview_wash.py
+++ b/interview_wash.py
@@ -251,7 +251,7 @@ def build_qa(notes: List[Dict[str, Any]]) -> List[Dict[str, Any]]:
     qa_dict: Dict[str, Dict[str, Any]] = {}
 
     def make_empty_qa(q: str) -> Dict[str, Any]:
-        return {"question": q, "sources": [], "categories": config.CATEGORIES}
+        return {"question": q, "sources": [], "categories": []}
 
     for note in notes:
         refined_in_note = note_to_refined[note["note_id"]]
@@ -284,6 +284,19 @@ def build_qa(notes: List[Dict[str, Any]]) -> List[Dict[str, Any]]:
                 "xsec_token": note.get("xsec_token", ""),
                 "desc": note.get("desc", ""),
             })
+            # 合并分类
+            note_categories = []
+            raw_cat = note.get("categories", [])
+            if isinstance(raw_cat, str):
+                try:
+                    note_categories = json.loads(raw_cat)
+                except Exception:
+                    note_categories = [c for c in raw_cat.split(",") if c]
+            elif isinstance(raw_cat, list):
+                note_categories = raw_cat
+            qa_dict[canon_q]["categories"] = list(
+                dict.fromkeys(qa_dict[canon_q]["categories"] + note_categories)
+            )
 
     # 转成 list
     return list(qa_dict.values())

--- a/schema/tables.sql
+++ b/schema/tables.sql
@@ -356,6 +356,7 @@ CREATE TABLE `xhs_note`
     `share_count`      varchar(16)  DEFAULT NULL COMMENT '笔记分享数',
     `image_list`       longtext COMMENT '笔记封面图片列表',
     `tag_list`         longtext COMMENT '标签列表',
+    `categories`       json NOT NULL COMMENT '分类列表',
     `note_url`         varchar(255) DEFAULT NULL COMMENT '笔记详情页的URL',
     PRIMARY KEY (`id`),
     KEY                `idx_xhs_note_note_id_209457` (`note_id`),

--- a/store/xhs/__init__.py
+++ b/store/xhs/__init__.py
@@ -14,6 +14,7 @@
 # @Time    : 2024/1/14 17:34
 # @Desc    :
 from typing import List
+import json
 
 import config
 from var import source_keyword_var
@@ -108,6 +109,7 @@ async def update_xhs_note(note_item: Dict):
         "note_url": f"https://www.xiaohongshu.com/explore/{note_id}?xsec_token={note_item.get('xsec_token')}&xsec_source=pc_search", # 帖子url
         "source_keyword": source_keyword_var.get(), # 搜索关键词
         "xsec_token": note_item.get("xsec_token"), # xsec_token
+        "categories": json.dumps(config.CATEGORIES, ensure_ascii=False),
     }
     utils.logger.info(f"[store.xhs.update_xhs_note] xhs note: {local_db_item}")
     await XhsStoreFactory.create_store().store_content(local_db_item)


### PR DESCRIPTION
## Summary
- support categories on `xhs_note` records
- store configured categories when saving notes
- aggregate note categories when generating interview questions

## Testing
- `python -m pytest -q` *(fails: ModuleNotFoundError: No module named 'playwright')*

------
https://chatgpt.com/codex/tasks/task_e_684975a6af98832ba8f4bc4eb9d69cd3