### PR TITLE
Add categories to zhihu content

### DIFF
--- a/model/m_zhihu.py
+++ b/model/m_zhihu.py
@@ -31,6 +31,7 @@ class ZhihuContent(BaseModel):
     voteup_count: int = Field(default=0, description="赞同人数")
     comment_count: int = Field(default=0, description="评论数量")
     source_keyword: str = Field(default="", description="来源关键词")
+    categories: list[str] = Field(default_factory=list, description="分类列表")
 
     user_id: str = Field(default="", description="用户ID")
     user_link: str = Field(default="", description="用户主页链接")

--- a/schema/tables.sql
+++ b/schema/tables.sql
@@ -529,6 +529,7 @@ CREATE TABLE `zhihu_content` (
     `user_nickname` varchar(64) NOT NULL COMMENT '用户昵称',
     `user_avatar` varchar(255) NOT NULL COMMENT '用户头像地址',
     `user_url_token` varchar(255) NOT NULL COMMENT '用户url_token',
+    `categories` json NOT NULL COMMENT '分类列表',
     `add_ts` bigint NOT NULL COMMENT '记录添加时间戳',
     `last_modify_ts` bigint NOT NULL COMMENT '记录最后修改时间戳',
     PRIMARY KEY (`id`),

--- a/store/zhihu/__init__.py
+++ b/store/zhihu/__init__.py
@@ -11,6 +11,7 @@
 
 # -*- coding: utf-8 -*-
 from typing import List
+import json
 
 import config
 from base.base_crawler import AbstractStore
@@ -62,7 +63,10 @@ async def update_zhihu_content(content_item: ZhihuContent):
     """
     content_item.source_keyword = source_keyword_var.get()
     local_db_item = content_item.model_dump()
-    local_db_item.update({"last_modify_ts": utils.get_current_timestamp()})
+    local_db_item.update({
+        "last_modify_ts": utils.get_current_timestamp(),
+        "categories": json.dumps(config.CATEGORIES, ensure_ascii=False),
+    })
     utils.logger.info(f"[store.zhihu.update_zhihu_content] zhihu content: {local_db_item}")
     await ZhihuStoreFactory.create_store().store_content(local_db_item)
 


### PR DESCRIPTION
## Summary
- support categories for Zhihu content
- import json in `store/zhihu/__init__.py`
- store categories when saving Zhihu content
- include categories column in schema
- add categories list to `ZhihuContent` model

## Testing
- `python3 -m pytest -q` *(fails: get ip error; redis connection refused)*

------
https://chatgpt.com/codex/tasks/task_e_684a74b3c448832b9bd02de2198b755c