### PR TITLE
Add is_analyzed to zhihu content

### DIFF
--- a/model/m_zhihu.py
+++ b/model/m_zhihu.py
@@ -32,6 +32,7 @@ class ZhihuContent(BaseModel):
     comment_count: int = Field(default=0, description="评论数量")
     source_keyword: str = Field(default="", description="来源关键词")
     categories: list[str] = Field(default_factory=list, description="分类列表")
+    is_analyzed: int = Field(default=0, description="是否已分析")
 
     user_id: str = Field(default="", description="用户ID")
     user_link: str = Field(default="", description="用户主页链接")

--- a/schema/tables.sql
+++ b/schema/tables.sql
@@ -532,6 +532,7 @@ CREATE TABLE `zhihu_content` (
     `categories` json NOT NULL COMMENT '分类列表',
     `add_ts` bigint NOT NULL COMMENT '记录添加时间戳',
     `last_modify_ts` bigint NOT NULL COMMENT '记录最后修改时间戳',
+    `is_analyzed` tinyint(1) DEFAULT 0 COMMENT '是否已分析',
     PRIMARY KEY (`id`),
     KEY `idx_zhihu_content_content_id` (`content_id`),
     KEY `idx_zhihu_content_created_time` (`created_time`)
@@ -593,6 +594,7 @@ alter table douyin_aweme_comment add column `like_count` varchar(255) NOT NULL D
 
 alter table xhs_note add column xsec_token varchar(50) default null comment '签名算法';
 alter table xhs_note add column is_analyzed tinyint(1) default 0 comment '是否已分析';
+alter table zhihu_content add column is_analyzed tinyint(1) default 0 comment '是否已分析';
 alter table douyin_aweme_comment add column `pictures` varchar(500) NOT NULL DEFAULT '' COMMENT '评论图片列表';
 
 -- add column `platform` to interview_question


### PR DESCRIPTION
## Summary
- add `is_analyzed` column for `zhihu_content` table
- support `is_analyzed` in Zhihu models
- update interview tools to track analyzed Zhihu records

## Testing
- `pytest -q` *(fails: Invalid port & Redis connection refused)*

------
https://chatgpt.com/codex/tasks/task_e_684aba14d264832b8c324ad704187c87