### PR TITLE
Add Niuke crawler storage

### DIFF
--- a/media_platform/niuke/core.py
+++ b/media_platform/niuke/core.py
@@ -11,6 +11,7 @@ from bs4 import BeautifulSoup
 import config
 from base.base_crawler import AbstractCrawler
 from tools import utils
+from store import niuke as niuke_store
 
 categories = [
     '腾讯',
@@ -34,7 +35,8 @@ class NiukeCrawler(AbstractCrawler):
         pass
 
     async def start(self):
-        await self.search()
+        items = await self.search()
+        await niuke_store.batch_update_niuke_notes(items)
 
     async def search(self):
         items = []

--- a/schema/tables.sql
+++ b/schema/tables.sql
@@ -588,6 +588,28 @@ CREATE TABLE `zhihu_creator` (
     UNIQUE KEY `idx_zhihu_creator_user_id` (`user_id`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci COMMENT='知乎创作者';
 
+-- ----------------------------
+-- Table structure for niuke_discussion
+-- ----------------------------
+DROP TABLE IF EXISTS `niuke_discussion`;
+CREATE TABLE `niuke_discussion` (
+    `id` int NOT NULL AUTO_INCREMENT COMMENT '自增ID',
+    `discuss_id` bigint NOT NULL COMMENT '帖子ID',
+    `title` varchar(255) DEFAULT NULL COMMENT '帖子标题',
+    `content` longtext,
+    `detailed_content` longtext,
+    `url` varchar(255) NOT NULL COMMENT '帖子链接',
+    `user` varchar(64) DEFAULT NULL COMMENT '用户昵称',
+    `categories` json NOT NULL COMMENT '分类列表',
+    `create_time` varchar(32) NOT NULL COMMENT '创建时间',
+    `edit_time` varchar(32) NOT NULL COMMENT '编辑时间',
+    `is_analyzed` tinyint(1) DEFAULT 0 COMMENT '是否已分析',
+    `add_ts` bigint NOT NULL COMMENT '记录添加时间戳',
+    `last_modify_ts` bigint NOT NULL COMMENT '记录最后修改时间戳',
+    PRIMARY KEY (`id`),
+    KEY `idx_niuke_discuss_id` (`discuss_id`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci COMMENT='牛客网帖子';
+
 
 -- add column `like_count` to douyin_aweme_comment
 alter table douyin_aweme_comment add column `like_count` varchar(255) NOT NULL DEFAULT '0' COMMENT '点赞数';

--- a/store/niuke/__init__.py
+++ b/store/niuke/__init__.py
@@ -1,0 +1,47 @@
+# -*- coding: utf-8 -*-
+from typing import List, Dict
+import json
+
+import config
+from base.base_crawler import AbstractStore
+from tools import utils
+
+from .niuke_store_impl import (
+    NiukeCsvStoreImplement,
+    NiukeDbStoreImplement,
+    NiukeJsonStoreImplement,
+)
+
+
+class NiukeStoreFactory:
+    STORES = {
+        "csv": NiukeCsvStoreImplement,
+        "db": NiukeDbStoreImplement,
+        "json": NiukeJsonStoreImplement,
+    }
+
+    @staticmethod
+    def create_store() -> AbstractStore:
+        store_class = NiukeStoreFactory.STORES.get(config.SAVE_DATA_OPTION)
+        if not store_class:
+            raise ValueError(
+                "[NiukeStoreFactory.create_store] Invalid save option only supported csv or db or json ..."
+            )
+        return store_class()
+
+
+async def batch_update_niuke_notes(notes: List[Dict]):
+    if not notes:
+        return
+    for note in notes:
+        await update_niuke_note(note)
+
+
+async def update_niuke_note(note_item: Dict):
+    note_item = note_item.copy()
+    note_item.update({
+        "last_modify_ts": utils.get_current_timestamp(),
+        "categories": json.dumps(note_item.get("categories", []), ensure_ascii=False),
+    })
+    utils.logger.info(f"[store.niuke.update_niuke_note] niuke note: {note_item}")
+    await NiukeStoreFactory.create_store().store_content(note_item)

--- a/store/niuke/niuke_store_impl.py
+++ b/store/niuke/niuke_store_impl.py
@@ -1,0 +1,117 @@
+# -*- coding: utf-8 -*-
+import asyncio
+import csv
+import json
+import os
+import pathlib
+from typing import Dict
+
+import aiofiles
+
+import config
+from base.base_crawler import AbstractStore
+from tools import utils, words
+from var import crawler_type_var
+
+
+def calculate_number_of_files(file_store_path: str) -> int:
+    if not os.path.exists(file_store_path):
+        return 1
+    try:
+        return max([
+            int(file_name.split("_")[0])
+            for file_name in os.listdir(file_store_path)
+        ]) + 1
+    except ValueError:
+        return 1
+
+
+class NiukeCsvStoreImplement(AbstractStore):
+    csv_store_path: str = "data/niuke"
+    file_count: int = calculate_number_of_files(csv_store_path)
+
+    def make_save_file_name(self, store_type: str) -> str:
+        return f"{self.csv_store_path}/{self.file_count}_{crawler_type_var.get()}_{store_type}_{utils.get_current_date()}.csv"
+
+    async def save_data_to_csv(self, save_item: Dict, store_type: str):
+        pathlib.Path(self.csv_store_path).mkdir(parents=True, exist_ok=True)
+        save_file_name = self.make_save_file_name(store_type)
+        async with aiofiles.open(save_file_name, mode='a+', encoding='utf-8-sig', newline='') as f:
+            writer = csv.writer(f)
+            if await f.tell() == 0:
+                await writer.writerow(save_item.keys())
+            await writer.writerow(save_item.values())
+
+    async def store_content(self, content_item: Dict):
+        await self.save_data_to_csv(content_item, "contents")
+
+    async def store_comment(self, comment_item: Dict):
+        await self.save_data_to_csv(comment_item, "comments")
+
+    async def store_creator(self, creator: Dict):
+        await self.save_data_to_csv(creator, "creator")
+
+
+class NiukeDbStoreImplement(AbstractStore):
+    async def store_content(self, content_item: Dict):
+        from .niuke_store_sql import (
+            add_new_content,
+            query_content_by_content_id,
+            update_content_by_content_id,
+        )
+        note_id = str(content_item.get("id"))
+        note_detail: Dict = await query_content_by_content_id(content_id=note_id)
+        if not note_detail:
+            content_item["add_ts"] = utils.get_current_timestamp()
+            await add_new_content(content_item)
+        else:
+            await update_content_by_content_id(note_id, content_item=content_item)
+
+    async def store_comment(self, comment_item: Dict):
+        pass
+
+    async def store_creator(self, creator: Dict):
+        pass
+
+
+class NiukeJsonStoreImplement(AbstractStore):
+    json_store_path: str = "data/niuke/json"
+    words_store_path: str = "data/niuke/words"
+    lock = asyncio.Lock()
+    file_count: int = calculate_number_of_files(json_store_path)
+    WordCloud = words.AsyncWordCloudGenerator()
+
+    def make_save_file_name(self, store_type: str) -> (str, str):
+        return (
+            f"{self.json_store_path}/{crawler_type_var.get()}_{store_type}_{utils.get_current_date()}.json",
+            f"{self.words_store_path}/{crawler_type_var.get()}_{store_type}_{utils.get_current_date()}",
+        )
+
+    async def save_data_to_json(self, save_item: Dict, store_type: str):
+        pathlib.Path(self.json_store_path).mkdir(parents=True, exist_ok=True)
+        pathlib.Path(self.words_store_path).mkdir(parents=True, exist_ok=True)
+        save_file_name, words_file_name_prefix = self.make_save_file_name(store_type)
+        save_data = []
+        async with self.lock:
+            if os.path.exists(save_file_name):
+                async with aiofiles.open(save_file_name, 'r', encoding='utf-8') as file:
+                    save_data = json.loads(await file.read())
+
+            save_data.append(save_item)
+            async with aiofiles.open(save_file_name, 'w', encoding='utf-8') as file:
+                await file.write(json.dumps(save_data, ensure_ascii=False, indent=4))
+
+            if config.ENABLE_GET_COMMENTS and config.ENABLE_GET_WORDCLOUD:
+                try:
+                    await self.WordCloud.generate_word_frequency_and_cloud(save_data, words_file_name_prefix)
+                except Exception:
+                    pass
+
+    async def store_content(self, content_item: Dict):
+        await self.save_data_to_json(content_item, "contents")
+
+    async def store_comment(self, comment_item: Dict):
+        await self.save_data_to_json(comment_item, "comments")
+
+    async def store_creator(self, creator: Dict):
+        await self.save_data_to_json(creator, "creator")

--- a/store/niuke/niuke_store_sql.py
+++ b/store/niuke/niuke_store_sql.py
@@ -1,0 +1,28 @@
+# -*- coding: utf-8 -*-
+from typing import Dict, List
+
+from db import AsyncMysqlDB
+from var import media_crawler_db_var
+
+
+async def query_content_by_content_id(content_id: str) -> Dict:
+    async_db_conn: AsyncMysqlDB = media_crawler_db_var.get()
+    sql: str = f"select * from niuke_discussion where discuss_id = '{content_id}'"
+    rows: List[Dict] = await async_db_conn.query(sql)
+    if len(rows) > 0:
+        return rows[0]
+    return dict()
+
+
+async def add_new_content(content_item: Dict) -> int:
+    async_db_conn: AsyncMysqlDB = media_crawler_db_var.get()
+    last_row_id: int = await async_db_conn.item_to_table("niuke_discussion", content_item)
+    return last_row_id
+
+
+async def update_content_by_content_id(content_id: str, content_item: Dict) -> int:
+    async_db_conn: AsyncMysqlDB = media_crawler_db_var.get()
+    effect_row: int = await async_db_conn.update_table(
+        "niuke_discussion", content_item, "discuss_id", content_id
+    )
+    return effect_row


### PR DESCRIPTION
## Summary
- add storage factory and implementations for Niuke crawler
- connect Niuke crawler to new store
- create SQL schema for Niuke discussions

## Testing
- `python3 -m pytest -q` *(fails: ModuleNotFoundError, ConnectionRefusedError)*

------
https://chatgpt.com/codex/tasks/task_e_6851030c5160832b9be854706fe11ffe